### PR TITLE
Add xygenibot auto-remediation workflow

### DIFF
--- a/.github/workflows/xygenibot.yml
+++ b/.github/workflows/xygenibot.yml
@@ -1,0 +1,80 @@
+# This workflow will execute Xygenibot on the project
+# Scan types controlled by org variables (XYGENIBOT_RUN_DEPS, XYGENIBOT_RUN_SAST, XYGENIBOT_RUN_SECRETS)
+# and overridable via workflow_dispatch inputs.
+
+name: Xygenibot
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      run_deps:
+        description: "Run dependency (SCA) auto-remediation"
+        type: boolean
+        default: true
+      run_sast:
+        description: "Run SAST auto-remediation"
+        type: boolean
+        default: false
+      run_secrets:
+        description: "Run secrets auto-remediation"
+        type: boolean
+        default: false
+
+jobs:
+  xygenibot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+
+      # https://github.com/marketplace/actions/maven-settings-action
+      - name: maven-settings
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
+        with:
+          servers: '[{"id": "github", "username": "dummy", "password": "${GITHUB_TOKEN_REF}"}]'
+          githubServer: false
+        env:
+          GITHUB_TOKEN_REF: ${{ github.token }}
+
+      # https://github.com/marketplace/actions/xygeni-scanner
+      - name: Deps auto-remediation
+        if: >-
+          (github.event_name == 'schedule' && vars.XYGENIBOT_RUN_DEPS != 'false') ||
+          (github.event_name == 'workflow_dispatch' && inputs.run_deps)
+        uses: xygeni/xygeni-action@13c6ed2797df7d85749864e2cbcf09c893f43b23 # v6.4.0
+        with:
+          command: deps --auto-remediate -f none
+          token: ${{ secrets.XYGENI_TOKEN_DEMO }}
+          gh_token: ${{ secrets.GH_PAT_FOR_DOGFOODING }}
+          xygeni_url: https://apidemo.xygeni.io/deps-doctor-service
+
+      - name: SAST auto-remediation
+        if: >-
+          (github.event_name == 'schedule' && vars.XYGENIBOT_RUN_SAST == 'true') ||
+          (github.event_name == 'workflow_dispatch' && inputs.run_sast)
+        uses: xygeni/xygeni-action@13c6ed2797df7d85749864e2cbcf09c893f43b23 # v6.4.0
+        with:
+          command: sast --auto-remediate -f none
+          token: ${{ secrets.XYGENI_TOKEN_DEMO }}
+          gh_token: ${{ secrets.GH_PAT_FOR_DOGFOODING }}
+          xygeni_url: https://apidemo.xygeni.io/deps-doctor-service
+
+      - name: Secrets auto-remediation
+        if: >-
+          (github.event_name == 'schedule' && vars.XYGENIBOT_RUN_SECRETS == 'true') ||
+          (github.event_name == 'workflow_dispatch' && inputs.run_secrets)
+        uses: xygeni/xygeni-action@13c6ed2797df7d85749864e2cbcf09c893f43b23 # v6.4.0
+        with:
+          command: secrets --auto-remediate -f none
+          token: ${{ secrets.XYGENI_TOKEN_DEMO }}
+          gh_token: ${{ secrets.GH_PAT_FOR_DOGFOODING }}
+          xygeni_url: https://apidemo.xygeni.io/deps-doctor-service


### PR DESCRIPTION
## Summary

- Deploy xygenibot workflow for automated vulnerability remediation (SPVS V2.4.14/V2.4.15/V2.6/V5.3.1)
- **Daily schedule:** runs `deps --auto-remediate` by default (controlled by org variable `XYGENIBOT_RUN_DEPS`)
- **Manual dispatch:** allows selecting deps, SAST, and/or secrets scans independently via workflow inputs
- SAST and secrets scans are OFF by default on schedule, controllable via org variables (`XYGENIBOT_RUN_SAST`, `XYGENIBOT_RUN_SECRETS`) — no workflow file changes needed to enable them
- All actions are SHA-pinned, permissions are explicitly scoped

## OWASP SPVS requirements addressed

- **V2.4.14/V2.4.15** (L2): Regular scanning of third-party libraries for known vulnerabilities
- **V2.6** (L3): Third-party library audit
- **V5.3.1** (L1): Timely application of patches and updates

## Test plan

- [ ] Verify workflow YAML is valid (GitHub flags syntax errors on push)
- [ ] After merge, trigger `workflow_dispatch` with default settings — verify deps scan runs
- [ ] Trigger `workflow_dispatch` with SAST enabled — verify SAST step executes
- [ ] Verify next daily scheduled run executes deps only

Part of xygeni/product-backlog#4435 | Epic xygeni/product-backlog#4433

🤖 Generated with [Claude Code](https://claude.com/claude-code)